### PR TITLE
EncryptionEncryption SecondPhase: Get public keys From Server For Group messaging

### DIFF
--- a/SECP-service/src/main/java/com/visucius/secp/Controllers/GroupController.java
+++ b/SECP-service/src/main/java/com/visucius/secp/Controllers/GroupController.java
@@ -286,13 +286,20 @@ public class GroupController {
     private GroupDTO getGroupResponse (Group group) {
         GroupDTO groupDTO = new GroupDTO(group.getId());
 
-        Set<UserDTO> users = group.getUsers().stream()
+        Set<UserDTO> users = getUsersInGroup(group).stream()
             .map(user -> {
                 return new UserDTO(user.getId(), getDevicesForUser(user));
             }).collect(Collectors.toSet());
 
         groupDTO.setUsers(users);
         return groupDTO;
+    }
+
+    private Set<User> getUsersInGroup(Group group) {
+        Set<User> users = new HashSet<>();
+        users.addAll(group.getUsers());
+        users.addAll(userRepository.findAdmins());
+        return users;
     }
 
     private Set<DeviceDTO> getDevicesForUser(User user) {

--- a/SECP-service/src/main/java/com/visucius/secp/Controllers/GroupController.java
+++ b/SECP-service/src/main/java/com/visucius/secp/Controllers/GroupController.java
@@ -9,6 +9,7 @@ import com.visucius.secp.daos.RolesDAO;
 import com.visucius.secp.daos.UserDAO;
 import com.visucius.secp.models.*;
 import com.visucius.secp.util.InputValidator;
+import com.visucius.secp.util.Util;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -297,8 +298,9 @@ public class GroupController {
 
     private Set<User> getUsersInGroup(Group group) {
         Set<User> users = new HashSet<>();
-        users.addAll(group.getUsers());
-        users.addAll(userRepository.findAdmins());
+        Util.addAllIfNotNull(users, group.getUsers());
+        Util.addAllIfNotNull(users, userRepository.findAdmins());
+
         return users;
     }
 

--- a/SECP-service/src/main/java/com/visucius/secp/DTO/GroupDTO.java
+++ b/SECP-service/src/main/java/com/visucius/secp/DTO/GroupDTO.java
@@ -1,0 +1,53 @@
+package com.visucius.secp.DTO;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+public class GroupDTO {
+    @JsonProperty
+    private long groupID;
+
+    @JsonProperty
+    private Set<UserDTO> users = new HashSet<>();
+
+    public GroupDTO(long groupID) {
+        this.groupID = groupID;
+    }
+
+    public long getGroupID() {
+        return groupID;
+    }
+
+    public void setGroupID(long groupID) {
+        this.groupID = groupID;
+    }
+
+    public Set<UserDTO> getUsers() {
+        return users;
+    }
+
+    public void setUsers(Set<UserDTO> users) {
+        this.users = users;
+    }
+
+    public void addUser(UserDTO user) {
+        this.users.add(user);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GroupDTO)) return false;
+        GroupDTO g = (GroupDTO) o;
+
+        return groupID == g.groupID && users.equals(g.users);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.groupID, this.users);
+    }
+}

--- a/SECP-service/src/main/java/com/visucius/secp/DTO/UserDTO.java
+++ b/SECP-service/src/main/java/com/visucius/secp/DTO/UserDTO.java
@@ -1,0 +1,57 @@
+package com.visucius.secp.DTO;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+public class UserDTO {
+    @JsonProperty
+    private long userID;
+
+    @JsonProperty
+    private Set<DeviceDTO> devices = new HashSet<>();
+
+    public UserDTO(long userID) {
+        this.userID = userID;
+    }
+
+    public UserDTO(long userID, Set<DeviceDTO> devices) {
+        this.userID = userID;
+        this.devices = devices;
+    }
+
+    public long getUserID() {
+        return userID;
+    }
+
+    public void setUserID(long userID) {
+        this.userID = userID;
+    }
+
+    public Set<DeviceDTO> getDevices() {
+        return devices;
+    }
+
+    public void setDevices(Set<DeviceDTO> devices) {
+        this.devices = devices;
+    }
+
+    public void addDevice(DeviceDTO device) {
+        devices.add(device);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserDTO)) return false;
+        UserDTO u = (UserDTO) o;
+        return userID == u.userID && devices.equals(u.devices);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.userID, this.devices);
+    }
+}

--- a/SECP-service/src/main/java/com/visucius/secp/daos/GroupDAO.java
+++ b/SECP-service/src/main/java/com/visucius/secp/daos/GroupDAO.java
@@ -2,6 +2,7 @@ package com.visucius.secp.daos;
 
 import com.google.common.base.Optional;
 import com.visucius.secp.models.Group;
+import com.visucius.secp.models.User;
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.HibernateException;
 import org.hibernate.SessionFactory;

--- a/SECP-service/src/main/java/com/visucius/secp/daos/UserDAO.java
+++ b/SECP-service/src/main/java/com/visucius/secp/daos/UserDAO.java
@@ -2,6 +2,7 @@ package com.visucius.secp.daos;
 
 import com.google.common.base.Optional;
 import com.visucius.secp.models.Device;
+import com.visucius.secp.models.LoginRole;
 import com.visucius.secp.models.User;
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.HibernateException;
@@ -102,5 +103,11 @@ public class UserDAO extends AbstractDAO<User> {
     {
         return (List<User>) namedQuery("com.visucius.secp.models.User.findUsersWithPermissionLevel").
             setParameter("permissionID",permissionID).list();
+    }
+
+    public List<User> findAdmins()
+    {
+        return (List<User>) namedQuery("com.visucius.secp.models.User.findAdmins").
+            setParameter("loginRole", LoginRole.ADMIN).list();
     }
 }

--- a/SECP-service/src/main/java/com/visucius/secp/models/User.java
+++ b/SECP-service/src/main/java/com/visucius/secp/models/User.java
@@ -27,7 +27,11 @@ import java.util.Set;
         @NamedQuery(
             name = "com.visucius.secp.models.User.findUsersWithPermissionLevel",
             query = "select u from User u join u.permissions p where p.id = :permissionID"
-        )
+        ),
+        @NamedQuery(
+            name = "com.visucius.secp.models.User.findAdmins",
+            query = "from User u where u.loginRole = :loginRole"
+        ),
     }
 )
 public class User implements Principal {

--- a/SECP-service/src/main/java/com/visucius/secp/util/Util.java
+++ b/SECP-service/src/main/java/com/visucius/secp/util/Util.java
@@ -1,0 +1,11 @@
+package com.visucius.secp.util;
+
+import java.util.Collection;
+
+public class Util {
+    public static <E> void addAllIfNotNull(Collection<E> list, Collection<? extends E> c) {
+        if (c != null) {
+            list.addAll(c);
+        }
+    }
+}

--- a/SECP-service/src/test/java/com/visucius/secp/Controllers/GroupControllerTest.java
+++ b/SECP-service/src/test/java/com/visucius/secp/Controllers/GroupControllerTest.java
@@ -1,8 +1,7 @@
 package com.visucius.secp.Controllers;
 
 import com.google.common.base.Optional;
-import com.visucius.secp.DTO.GroupCreateRequest;
-import com.visucius.secp.DTO.GroupModifyRequest;
+import com.visucius.secp.DTO.*;
 import com.visucius.secp.daos.GroupDAO;
 import com.visucius.secp.daos.PermissionDAO;
 import com.visucius.secp.daos.RolesDAO;
@@ -313,7 +312,7 @@ public class GroupControllerTest {
 
 
         Response response = controller.addRolesToGroup(request, groupWithRolesID);
-        Response validResponse = Response.status(Response.Status.CREATED).entity(1L).build();
+        Response validResponse = Response.status(Response.Status.CREATED).entity(getGroupResponse()).build();
         assertEquals(response.getStatus(), validResponse.getStatus());
         assertEquals(response.getEntity(),  validResponse.getEntity());
     }
@@ -329,7 +328,7 @@ public class GroupControllerTest {
         );
 
         Response response = controller.addPermissionsToGroup(request, groupWithRolesID);
-        Response validResponse = Response.status(Response.Status.CREATED).entity(1L).build();
+        Response validResponse = Response.status(Response.Status.CREATED).entity(getGroupResponse()).build();
         assertEquals(response.getStatus(), validResponse.getStatus());
         assertEquals(response.getEntity(),  validResponse.getEntity());
     }
@@ -349,7 +348,7 @@ public class GroupControllerTest {
         );
 
         Response response = controller.addPermissionsToGroup(request, groupWithRolesID);
-        Response validResponse = Response.status(Response.Status.CREATED).entity(1L).build();
+        Response validResponse = Response.status(Response.Status.CREATED).entity(getGroupResponse()).build();
         assertEquals(response.getStatus(), validResponse.getStatus());
         assertEquals(response.getEntity(),  validResponse.getEntity());
     }
@@ -369,7 +368,7 @@ public class GroupControllerTest {
         );
 
         Response response = controller.addRolesToGroup(request, groupWithRolesID);
-        Response validResponse = Response.status(Response.Status.CREATED).entity(1L).build();
+        Response validResponse = Response.status(Response.Status.CREATED).entity(getGroupResponse()).build();
         assertEquals(response.getStatus(), validResponse.getStatus());
         assertEquals(response.getEntity(),  validResponse.getEntity());
     }
@@ -389,7 +388,7 @@ public class GroupControllerTest {
         );
 
         Response response = controller.deletePermissions(request, groupWithRolesID);
-        Response validResponse = Response.status(Response.Status.CREATED).entity(1L).build();
+        Response validResponse = Response.status(Response.Status.CREATED).entity(getGroupResponse()).build();
         assertEquals(response.getStatus(), validResponse.getStatus());
         assertEquals(response.getEntity(),  validResponse.getEntity());
     }
@@ -409,9 +408,10 @@ public class GroupControllerTest {
         );
 
         Response response = controller.deleteRoles(request, groupWithRolesID);
-        Response validResponse = Response.status(Response.Status.CREATED).entity(1L).build();
+        Response validResponse = Response.status(Response.Status.CREATED).entity(getGroupResponse()).build();
         assertEquals(response.getStatus(), validResponse.getStatus());
         assertEquals(response.getEntity(),  validResponse.getEntity());
+
     }
 
     @Test
@@ -420,7 +420,7 @@ public class GroupControllerTest {
         GroupModifyRequest request = new GroupModifyRequest();
 
         Response response =  controller.addRolesToGroup(request, groupWithRolesID);
-        Response validResponse = Response.status(Response.Status.CREATED).entity(1L).build();
+        Response validResponse = Response.status(Response.Status.CREATED).entity(getGroupResponse()).build();
         assertEquals(response.getStatus(), validResponse.getStatus());
         assertEquals(response.getEntity(),  validResponse.getEntity());
     }
@@ -435,8 +435,13 @@ public class GroupControllerTest {
         );
 
         Response response = controller.createGroup(request);
-        Response validResponse = Response.status(Response.Status.CREATED).entity(1L).build();
+        Response validResponse = Response.status(Response.Status.CREATED).entity(getGroupResponse()).build();
         assertEquals(response.getStatus(), validResponse.getStatus());
         assertEquals(response.getEntity(),  validResponse.getEntity());
+    }
+
+    private GroupDTO getGroupResponse () {
+        GroupDTO groupDTO = new GroupDTO(1L);
+        return groupDTO;
     }
 }

--- a/SECP-service/src/test/java/com/visucius/secp/DTO/GroupDTOTest.java
+++ b/SECP-service/src/test/java/com/visucius/secp/DTO/GroupDTOTest.java
@@ -1,0 +1,38 @@
+package com.visucius.secp.DTO;
+
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class GroupDTOTest {
+    private final long groupID = 1;
+
+
+    @Test
+    public void testGroupID() {
+        GroupDTO groupDTO = new GroupDTO(groupID);
+        groupDTO.setGroupID(groupID);
+        assertEquals("group id is not equal",groupID, groupDTO.getGroupID());
+    }
+
+    @Test
+    public void testUsers() {
+        GroupDTO groupDTO = new GroupDTO(groupID);
+
+        UserDTO userDTO = new UserDTO(1);
+        Set<UserDTO> users = new HashSet<>();
+        users.add(userDTO);
+
+        groupDTO.setUsers(users);
+        assertEquals("users are is not equal", users, groupDTO.getUsers());
+    }
+
+    @Test
+    public void testConstructor() {
+        GroupDTO groupDTO = new GroupDTO(groupID);
+        assertEquals("groupD is not equal",groupID, groupDTO.getGroupID());
+    }
+}

--- a/SECP-service/src/test/java/com/visucius/secp/DTO/UserDTOTest.java
+++ b/SECP-service/src/test/java/com/visucius/secp/DTO/UserDTOTest.java
@@ -1,0 +1,43 @@
+package com.visucius.secp.DTO;
+
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class UserDTOTest {
+    private final long userID = 1;
+
+
+    @Test
+    public void testUserID() {
+        UserDTO userDTO = new UserDTO(userID);
+        userDTO.setUserID(userID);
+        assertEquals("user id is not equal", userID, userDTO.getUserID());
+    }
+
+    @Test
+    public void testDevices() {
+        UserDTO userDTO = new UserDTO(userID);
+
+        DeviceDTO deviceDTO = new DeviceDTO(1, "key");
+        Set<DeviceDTO> devices = new HashSet<>();
+        devices.add(deviceDTO);
+
+        userDTO.setDevices(devices);
+        assertEquals("devices are not equal", devices, userDTO.getDevices());
+    }
+
+    @Test
+    public void testConstructor() {
+        DeviceDTO deviceDTO = new DeviceDTO(1, "key");
+        Set<DeviceDTO> devices = new HashSet<>();
+        devices.add(deviceDTO);
+
+        UserDTO userDTO = new UserDTO(userID, devices);
+        assertEquals("userID is not equal", userID, userDTO.getUserID());
+        assertEquals("devices are not equal", devices, userDTO.getDevices());
+    }
+}

--- a/SECP-service/src/test/java/com/visucius/secp/models/UserTest.java
+++ b/SECP-service/src/test/java/com/visucius/secp/models/UserTest.java
@@ -112,7 +112,7 @@ public class UserTest {
 
         //testing the @JoinTable annotation
         NamedQueries namedQueries = ReflectTool.getClassAnnotation(User.class, NamedQueries.class);
-        assertEquals("NamedQueries:  size is not equal to 4", 4, namedQueries.value().length);
+        assertEquals("NamedQueries:  size is not equal to 5", 5, namedQueries.value().length);
 
         NamedQuery[] namedQueriesArray = namedQueries.value();
 
@@ -124,6 +124,8 @@ public class UserTest {
             "com.visucius.secp.models.User.findUsersWithRole", namedQueriesArray[2].name());
         assertEquals("NamedQueries[3]: name is not equal",
             "com.visucius.secp.models.User.findUsersWithPermissionLevel", namedQueriesArray[3].name());
+        assertEquals("NamedQueries[4]: name is not equal",
+            "com.visucius.secp.models.User.findAdmins", namedQueriesArray[4].name());
     }
 
     @Test


### PR DESCRIPTION
The second phase of the encryption is to get the public keys of the devices for all the users in a group. These public keys would be used in the third phase to send the secret key of a group to each device.

NOTE: The public keys for admins are returned too for auditing purposes. That way the admins can have the secret key too.